### PR TITLE
DockerでMySQLの構築

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM mysql:8.0-debian
+RUN apt-get update
+RUN apt-get -y install locales-all
+ENV LANG ja_JP.UTF-8
+ENV LANGUAGE ja_JP:ja
+ENV LC_ALL ja_JP.UTF-8
+COPY ./conf/mysql/my.cnf /etc/my.cnf

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ conf/  docker-compose.yml  Dockerfile  LICENSE  mvnw*  mvnw.cmd  pom.xml  README
 ただし初回は時間がかかります。
 出力内容も下記より多いです。
 ```bash
+$ docker compose up -d
 [+] Running 2/2
  - Network projectsForT_default  Created                                                                      0.9s
  - Container Mysql_Intern_db        Started                                                                      1.9s

--- a/README.md
+++ b/README.md
@@ -25,6 +25,119 @@ Login するときUserを確認することと Logout したら　ホームペ�
 
 ## Getting Start
 
+Dockerを使ってMySQLを構築しましょう。
+
+## Dockerの準備
+Dockerをinstallする。
+確認方法はターミナルから下記を実行する。
+```bash
+$ docker -v
+Docker version 20.10.17, build 100c701
+```
+
+## 手順
+
+まずは、レポジトリをcloneします。
+cloneしたらディレクトリ内に移動します。
+docker-compose.ymlがあることを確認する。
+
+```bash
+$ ls
+conf/  docker-compose.yml  Dockerfile  LICENSE  mvnw*  mvnw.cmd  pom.xml  README.md  sql/  src/
+```
+
+コンテナを起動する。
+ただし初回は時間がかかります。
+出力内容も下記より多いです。
+```bash
+[+] Running 2/2
+ - Network projectsForT_default  Created                                                                      0.9s
+ - Container Mysql_Intern_db        Started                                                                      1.9s
+```
+
+コンテナを確認する。
+"Mysql_Intern_db"があればOKです。
+```bash
+$ docker ps
+CONTAINER ID   IMAGE                COMMAND                  CREATED          STATUS          PORTS                               NAMES
+7e583596bcaf   projectsForT_db   "docker-entrypoint.s…"   47 seconds ago   Up 45 seconds   33060/tcp, 0.0.0.0:3307->3306/tcp   Mysql_Intern_db
+```
+
+MYSQLにLoginします。パスワードはdocker-compose.ymlに記載されているとおり"admin"です。
+```bash
+$ docker compose exec db mysql -u user -p
+Enter password:
+```
+
+もし、パスワードを入力したあと動作しないこともあります。Window環境の方は下記のコメントを入力して試してください。
+```bash
+$ winpty docker compose exec db mysql -u user -p
+Enter password:
+```
+
+以下のように表示されるとDatabaseを使いましょう。
+```bash
+$ docker compose exec db mysql -u user -p
+Enter password:
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 11
+Server version: 8.0.29 MySQL Community Server - GPL
+
+Copyright (c) 2000, 2022, Oracle and/or its affiliates.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql>
+```
+
+"show databases;"　コメントを入力して、intern_dbがあることを確認する。
+```bash
+mysql> show databases;
++--------------------+
+| Database           |
++--------------------+
+| information_schema |
+| intern_db          |
++--------------------+
+2 rows in set (0.01 sec)
+```
+
+"intern_db"の利用を開始する。
+```bash
+mysql> use intern_db;
+Reading table information for completion of table and column names
+You can turn off this feature to get a quicker startup with -A
+
+Database changed
+```
+
+"account"テーブルがあることを確認する。
+```bash
+mysql> show tables;
++---------------------+
+| Tables_in_intern_db |
++---------------------+
+| account             |
++---------------------+
+1 row in set (0.01 sec)
+
+```
+
+以下のコメントを使って"account"テーブルのレコードを確認する。
+```bash
+mysql> select * from account;
++----+-----------------+-------+------+--------------------------------------------------------------+
+| id | email           | name  | role | password                                                     |
++----+-----------------+-------+------+--------------------------------------------------------------+
+|  1 | admin@gmail.com | admin |    0 | $2a$10$V2P4daPnPXxBsYNGNpBwmu.A91IXrzyJUUsU8E21Iz5foXhVlN3Sq |
++----+-----------------+-------+------+--------------------------------------------------------------+
+1 row in set (0.00 sec)
+```
+
 アプリを始める前にまずMySQL Databaseに'intern_db'の名前でdatabase作成してください。
 
 <img width="700" height="200" alt="database作成" src="https://user-images.githubusercontent.com/100908505/178402989-f0e31ceb-8f66-4bd4-ad3f-581dbcea7795.png">
@@ -74,6 +187,27 @@ http://localhost:8080/homepage をアクセスすると検索画面が表示さ�
 **Sign-Out画面(ホームページ)**
 
 <img src="https://user-images.githubusercontent.com/100908505/178428233-8588acfd-db7d-4e21-a6e7-668ab5d94e6b.png">
+
+ログアウトする。
+```bash
+mysql> exit
+Bye
+```
+
+起動したDockerコンテナを停止する。
+```bash
+$ docker compose down
+[+] Running 2/2
+ - Container Mysql_Intern_db        Removed                                                                      1.7s
+ - Network projectsForT_default  Removed                                                                      0.8s
+```
+
+停止できていることを確認する。
+```bash
+$ docker ps
+CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
+
+```
 
 終了です。
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ http://localhost:8080/homepage をアクセスすると検索画面が表示さ�
 
 <img src="https://user-images.githubusercontent.com/100908505/178428233-8588acfd-db7d-4e21-a6e7-668ab5d94e6b.png">
 
-ログアウトする。
+Mysqlをログアウトする。
 ```bash
 mysql> exit
 Bye

--- a/README.md
+++ b/README.md
@@ -139,10 +139,6 @@ mysql> select * from account;
 1 row in set (0.00 sec)
 ```
 
-アプリを始める前にまずMySQL Databaseに'intern_db'の名前でdatabase作成してください。
-
-<img width="700" height="200" alt="database作成" src="https://user-images.githubusercontent.com/100908505/178402989-f0e31ceb-8f66-4bd4-ad3f-581dbcea7795.png">
-
 **起動成功時のイメージ**
 
 <img width="700" src="https://user-images.githubusercontent.com/100908505/178414780-35d7d6b7-4388-4c9a-8466-7b08fe5e99c1.png">

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Spring boot 2.7.1
 - ThymeLeaf view
 - Spring Security
+- Docker
 - MySQL
 
 ## 名レイヤの責務

--- a/conf/mysql/my.cnf
+++ b/conf/mysql/my.cnf
@@ -1,0 +1,11 @@
+[mysqld]
+skip-character-set-client-handshake
+default-time-zone='+9:00'
+character-set-server = utf8mb4
+collation-server = utf8mb4_general_ci
+slow_query_log = 1
+slow_query_log_file = /var/log/slow_query.log
+long_query_time = 1
+
+[client]
+default-character-set = utf8mb4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  db:
+    build: .
+    container_name: Mysql_Intern_db
+    platform: linux/x86_64
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: admin
+      MYSQL_DATABASE: intern_db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: admin
+    ports:
+      - 3307:3306
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -1,0 +1,12 @@
+drop table if exists account;
+
+create table account(
+	id int primary key not null auto_increment,
+    email varchar(50) not null unique,
+    name varchar(50) not null,
+    role int not null,
+    password varchar(255) not null
+);
+
+insert into account(email, name, role, password) values
+	('admin@gmail.com', 'admin', 0, '$2a$10$V2P4daPnPXxBsYNGNpBwmu.A91IXrzyJUUsU8E21Iz5foXhVlN3Sq');

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -1,12 +1,12 @@
-drop table if exists account;
+DROP TABLE IF EXISTS account;
 
-create table account(
-	id int primary key not null auto_increment,
-    email varchar(50) not null unique,
-    name varchar(50) not null,
-    role int not null,
-    password varchar(255) not null
+CREATE TABLE account (
+    id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    email VARCHAR(50) NOT NULL UNIQUE,
+    name VARCHAR(50) NOT NULL,
+    role INT NOT NULL,
+    password VARCHAR(255) NOT NULL
 );
 
-insert into account(email, name, role, password) values
+INSERT INTO account(email, name, role, password) VALUES
 	('admin@gmail.com', 'admin', 0, '$2a$10$V2P4daPnPXxBsYNGNpBwmu.A91IXrzyJUUsU8E21Iz5foXhVlN3Sq');

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/intern_db
-spring.datasource.username=root
+spring.datasource.url=jdbc:mysql://localhost:3307/intern_db
+spring.datasource.username=user
 spring.datasource.password=admin
 
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 


### PR DESCRIPTION
# 概要

MySQLの構築をDockerでできるようにしました。

# やってみたこと

MySQLコンテナを起動するためのファイルを追加しました。
そして、READMEにもDockerの起動手順を追加しました。
"application.proeperties"にDockerのMySQLを使えるようにしました。